### PR TITLE
Parser#initialize: read file when filename given

### DIFF
--- a/lib/quicken_parser/parser.rb
+++ b/lib/quicken_parser/parser.rb
@@ -4,7 +4,8 @@ require "time"
 module QuickenParser
   class Parser #:nodoc:
     def initialize(source)
-      @input = source.respond_to?(:read) ? source.read : source
+      @input = source.respond_to?(:read) ? source.read :
+        File.exists?(source) ? File.open(source).read : source
     end
 
     def parse

--- a/lib/quicken_parser/version.rb
+++ b/lib/quicken_parser/version.rb
@@ -1,3 +1,3 @@
 module QuickenParser
-  VERSION = "0.2.0"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
It seems natural to pass a filename to initialize, so if whatever we're
given is a file that exists, read its contents instead of using it as
string data directly.

(It occurs to me that we may want to duplicate the string otherwise, but
I'm unsure what other use cases might be present that I'm not thinking
of, so I'm leaving that out for now.)

Fixes #2

Note: Chosing to bump version to 0.2.2 because rubygems has a 0.2.1 from
somewhere that I couldn't find.

This change technically Copyright 2021 by David Lindes, and I agree to
license it under the same terms as the rest of this repository.