### PR TITLE
New version with ability to access Parser object, including Parser#metadata

### DIFF
--- a/lib/quicken_parser.rb
+++ b/lib/quicken_parser.rb
@@ -5,7 +5,16 @@ Dir[File.dirname(__FILE__) + "/**/*.rb"].each {|f| require f}
 require "money"
 
 module QuickenParser
+  # New API (in version 0.3.0), to allow direct access to the Parser
+  # object, which (now) has other (potentially) useful methods than just
+  # #accounts (notably: #metadata):
+  def self.parser(stream_or_string)
+    Parser.new(stream_or_string).parse
+  end
+
+  # For backwards compatability, we still provide a version (by the
+  # original name) that gives #accounts back:
   def self.parse(stream_or_string)
-    Parser.new(stream_or_string).parse.accounts
+    parser(stream_or_string).accounts
   end
 end

--- a/lib/quicken_parser/parser.rb
+++ b/lib/quicken_parser/parser.rb
@@ -4,7 +4,8 @@ require "time"
 module QuickenParser
   class Parser #:nodoc:
     def initialize(source)
-      @input = source.respond_to?(:read) ? source.read : source
+      @input = source.respond_to?(:read) ? source.read :
+        File.exists?(source) ? File.open(source).read : source
     end
 
     def parse

--- a/lib/quicken_parser/parser.rb
+++ b/lib/quicken_parser/parser.rb
@@ -32,6 +32,33 @@ module QuickenParser
       @accounts
     end
 
+    def metadata
+      # Note: I expect only one of these:
+      REXML::XPath.each(@doc.root, "//SONRS") do |xml|
+	@metadata = metadata_from_xml(xml)
+      end
+      @metadata
+    end
+
+    def metadata_from_xml(xml)
+      # https://schemas.liquid-technologies.com/ofx/2.1.1/?page=sonrs.html
+      {
+	status: {
+	  code: REXML::XPath.first(xml, ".//STATUS/CODE").text,
+	  severity: REXML::XPath.first(xml, ".//STATUS/SEVERITY").text,
+	},
+	server_date: Time.parse(REXML::XPath.first(xml, ".//DTSERVER").text + "Z"),
+	lang: REXML::XPath.first(xml, ".//LANGUAGE").text,
+	profile_date: Time.parse(REXML::XPath.first(xml, ".//DTPROFUP").text + "Z"),
+	financial_institution: {
+	  name: REXML::XPath.first(xml, ".//FI/ORG").text,
+	  id: REXML::XPath.first(xml, ".//FI/FID").text,
+	},
+	# Not in the above-linked spec, but seen in a QFX file:
+	user: REXML::XPath.first(xml, ".//INTU.USERID").text,
+      }
+    end
+
     def cc_account_from_xml(xml)
       currency     = REXML::XPath.first(xml, ".//CURDEF").text
       bank_id      = nil

--- a/lib/quicken_parser/version.rb
+++ b/lib/quicken_parser/version.rb
@@ -1,3 +1,3 @@
 module QuickenParser
-  VERSION = "0.2.0"
+  VERSION = "0.2.2"
 end

--- a/lib/quicken_parser/version.rb
+++ b/lib/quicken_parser/version.rb
@@ -1,3 +1,3 @@
 module QuickenParser
-  VERSION = "0.2.2"
+  VERSION = "0.3.0"
 end

--- a/quicken_parser.gemspec
+++ b/quicken_parser.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.email = %q{francois@teksol.info}
   s.extra_rdoc_files = ["README", "LICENSE", "TODO"]
   s.files = ["LICENSE", "README", "Rakefile", "TODO", "lib/quicken_parser", "lib/quicken_parser/account.rb", "lib/quicken_parser/parser.rb", "lib/quicken_parser/transaction.rb", "lib/quicken_parser/transactions.rb", "lib/quicken_parser.rb", "test/account_test.rb", "test/fixtures", "test/fixtures/no_memo.txt", "test/fixtures/one_account.txt", "test/fixtures/one_cc.txt", "test/fixtures/two_accounts.txt", "test/money_test.rb", "test/parser_test.rb", "test/test_helper.rb", "test/transaction_test.rb", "test/transactions_test.rb"]
-  s.has_rdoc = true
   s.homepage = %q{http://github.com/francois/quicken_parser}
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.2}


### PR DESCRIPTION
I found these changes to be helpful for my own usage, in particular so that I could keep better track of multiple .qfx files by having access to the date information contained in them.

Because I added a new (though backwards-compatible) API on QuickenParser, I've bumped the minor version number to 0.3.0.

If you like these changes, I'd appreciate being merged in.  If not, no worries!